### PR TITLE
Add an option to auto select best skill for calculating mortar accuracy.

### DIFF
--- a/MortarAccuracy/Languages/English/Keyed/Keys.xml
+++ b/MortarAccuracy/Languages/English/Keyed/Keys.xml
@@ -6,6 +6,8 @@
 	<OptionSkills>Which skill(s) affect accuracy. If multiple skills are selected, they are averaged together.</OptionSkills>
 	<OptionSkillIntellectual>Intellectual skill affects accuracy</OptionSkillIntellectual>
 	<OptionSkillShooting>Shooting skill affects accuracy</OptionSkillShooting>
+	<OptionSkillsBest>Highest skill affects accuracy</OptionSkillsBest>
+	<OptionSkillsBestTooltip>Choose whether to use the highest between intellectual or shooting for mortar accuracy or an average of the two skills.</OptionSkillsBestTooltip>
 	<OptionBestAccuracy>Best accuracy\nPawns with maximum skill have their mortar accuracy improved to {0}% (vanilla is 0%, mod default is 75%, perfect accuracy is 100%)</OptionBestAccuracy>
 	<OptionWorstAccuracy>Worst accuracy\nPawns with no skill have their mortar accuracy {0} by {1}% (vanilla is 0%, mod default is -50%)</OptionWorstAccuracy>
 	<Improved>improved</Improved>

--- a/Source/PatsMortarAccuracy/Patches.cs
+++ b/Source/PatsMortarAccuracy/Patches.cs
@@ -454,6 +454,11 @@ namespace MortarAccuracy
                         totalSkill += shooterPawn.skills.GetSkill(SkillDefOf.Shooting).Level;
                         skillsTotaled++;
                     }
+                    if (Settings.bestSkillAffectsMotarAccuracy)
+                    {
+                        totalSkill = Math.Max(shooterPawn.skills.GetSkill(SkillDefOf.Intellectual).Level, shooterPawn.skills.GetSkill(SkillDefOf.Shooting).Level);
+                        skillsTotaled = 1;
+                    }
                     if (skillsTotaled > 0)
                     {
                         // get average skill

--- a/Source/PatsMortarAccuracy/Settings.cs
+++ b/Source/PatsMortarAccuracy/Settings.cs
@@ -7,6 +7,7 @@ namespace MortarAccuracy
     {
         public static bool intellectualAffectsMortarAccuracy = true;
         public static bool shootingAffectsMortarAccuracy = false;
+        public static bool bestSkillAffectsMotarAccuracy = false;
         public static bool weatherAffectsMortarAccuracy = true;
         public static float maxSkillSpreadReduction = 0.75f;
         public static float minSkillSpreadReduction = -0.4f;
@@ -17,6 +18,7 @@ namespace MortarAccuracy
         {
             Scribe_Values.Look(ref intellectualAffectsMortarAccuracy, "intellectualAffectsMortarAccuracy", true);
             Scribe_Values.Look(ref shootingAffectsMortarAccuracy, "shootingAffectsMortarAccuracy", false);
+            Scribe_Values.Look(ref bestSkillAffectsMotarAccuracy, "bestSkillAffectsMortarAccuracy", false);
             Scribe_Values.Look(ref weatherAffectsMortarAccuracy, "weatherAffectsMortarAccuracy", true);
             Scribe_Values.Look(ref showExplosionRadius, "showExplosionRadius", true);
             Scribe_Values.Look(ref maxSkillSpreadReduction, "maxSkillSpreadReduction", 0.75f);
@@ -42,6 +44,11 @@ namespace MortarAccuracy
             listingStandard.Label(Translator.Translate("OptionSkills"));
             listingStandard.CheckboxLabeled(Translator.Translate("OptionSkillIntellectual"), ref Settings.intellectualAffectsMortarAccuracy);
             listingStandard.CheckboxLabeled(Translator.Translate("OptionSkillShooting"), ref Settings.shootingAffectsMortarAccuracy);
+            
+            if (Settings.intellectualAffectsMortarAccuracy && Settings.shootingAffectsMortarAccuracy)
+                listingStandard.CheckboxLabeled(Translator.Translate("OptionSkillsBest"), ref Settings.bestSkillAffectsMotarAccuracy, Translator.Translate("OptionSkillsBestTooltip"));
+            else
+                Settings.bestSkillAffectsMotarAccuracy = false;
 
             listingStandard.Label(TranslatorFormattedStringExtensions.Translate("OptionBestAccuracy", (int)(Settings.maxSkillSpreadReduction * 100)));
             Settings.maxSkillSpreadReduction = listingStandard.Slider(Settings.maxSkillSpreadReduction, 0f, 1f);


### PR DESCRIPTION
Also adds an option in the settings that defaults to false and is only visible when shooting and intelligence skills are true. 
<img width="1884" height="1176" alt="BestSkill Setting" src="https://github.com/user-attachments/assets/d3ccedc1-0b47-4790-8393-072042df7da3" />


May need someone to add translations for the new settings!